### PR TITLE
update to account for Omega 2+ firmware newer than v.0.3.0

### DIFF
--- a/sdboot.sh
+++ b/sdboot.sh
@@ -9,11 +9,11 @@ NC='\033[0m' # No Color
 
 printf "\n${GREEN}Installing kmod...${NC}\n"
 opkg update
-opkg upgrade
+#opkg upgrade
 opkg install kmod-usb-storage-extras e2fsprogs kmod-fs-ext4
 
 printf "\n${GREEN}Formatting the SD card...${NC}\n"
-umount /tmp/mounts/SD-P1/
+umount /mnt/mmcblk0p1
 mkfs.ext4 /dev/mmcblk0p1
 
 printf "\n${GREEN}Mounting the SD card...${NC}\n" 


### PR DESCRIPTION
This pull request makes changes required because of the new mounting point, `/mnt`, for SD cards in the firmware after v0.3.0.

See [this page](https://docs.onion.io/omega2-docs/using-a-microsd-card.html#accessing-the-microsd-card) in the docs.

resolves #1 